### PR TITLE
Fix: Separate Soundcloud API Model

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #[macro_use]
 extern crate serde_derive;
 
+pub mod soundcloud_api;
+pub use soundcloud_api::*;
+
 pub mod user;
 pub use user::*;
 

--- a/src/soundcloud_api/mod.rs
+++ b/src/soundcloud_api/mod.rs
@@ -1,0 +1,2 @@
+pub mod responses;
+pub use responses::*;

--- a/src/soundcloud_api/responses.rs
+++ b/src/soundcloud_api/responses.rs
@@ -1,40 +1,28 @@
-use crate::SoundcloudUser;
+use serde::Deserialize;
 
-struct User {
-    id: u32,
-    username: String,
-    avatar_url: String,
-    permalink_url: String,
-    city: String,
-    country: String,
-    public_songs_count: u32,
-    private_songs_count: u32,
-
-    // TODO: Add users songs here as a list once we have Song domain model.
-}
-
-impl From<SoundcloudUser> for User {
-    fn from(s_user: SoundcloudUser) -> Self {
-        User {
-            id: s_user.id,
-            username: s_user.username,
-            avatar_url: s_user.avatar_url,
-            permalink_url: s_user.permalink_url,
-            city: s_user.city,
-            country: s_user.country,
-            public_songs_count: s_user.track_count,
-            private_songs_count: s_user.private_tracks_count,
-        }
-    }
+#[derive(Deserialize, Clone)]
+pub struct SoundcloudUser {
+    pub id: u32,
+    pub username: String,
+    pub uri: String,
+    pub permalink_url: String,
+    pub avatar_url: String,
+    pub country: String,
+    pub full_name: String,
+    pub city: String,
+    pub description: String,
+    pub website: String,
+    pub track_count: u32,
+    pub private_tracks_count: u32,
+    pub primary_email_confirmed: bool,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::User;
-    use crate::SoundcloudUser;
+    use super::SoundcloudUser;
 
     #[test]
-    fn mapping_from_soundcloud_user_works() {
+    fn mapping_from_api_response_works() {
         let mock_api_response = r#"
         {
           "id": 3207,
@@ -63,9 +51,8 @@ mod tests {
           "primary_email_confirmed": true
         }"#;
 
-        let s_user: SoundcloudUser = serde_json::from_str(mock_api_response).unwrap();
-        let u = User::from(s_user.clone());
+        let u: SoundcloudUser = serde_json::from_str(mock_api_response).unwrap();
 
-        assert_eq!(u.id, s_user.id);
+        assert_eq!(u.id, 3207);
     }
 }

--- a/src/soundcloud_api/responses.rs
+++ b/src/soundcloud_api/responses.rs
@@ -1,5 +1,3 @@
-use serde::Deserialize;
-
 #[derive(Deserialize, Clone)]
 pub struct SoundcloudUser {
     pub id: u32,
@@ -7,14 +5,6 @@ pub struct SoundcloudUser {
     pub uri: String,
     pub permalink_url: String,
     pub avatar_url: String,
-    pub country: String,
-    pub full_name: String,
-    pub city: String,
-    pub description: String,
-    pub website: String,
-    pub track_count: u32,
-    pub private_tracks_count: u32,
-    pub primary_email_confirmed: bool,
 }
 
 #[cfg(test)]

--- a/src/user.rs
+++ b/src/user.rs
@@ -5,11 +5,6 @@ struct User {
     username: String,
     avatar_url: String,
     permalink_url: String,
-    city: String,
-    country: String,
-    public_songs_count: u32,
-    private_songs_count: u32,
-
     // TODO: Add users songs here as a list once we have Song domain model.
 }
 
@@ -20,10 +15,6 @@ impl From<SoundcloudUser> for User {
             username: s_user.username,
             avatar_url: s_user.avatar_url,
             permalink_url: s_user.permalink_url,
-            city: s_user.city,
-            country: s_user.country,
-            public_songs_count: s_user.track_count,
-            private_songs_count: s_user.private_tracks_count,
         }
     }
 }


### PR DESCRIPTION
This PR adds a fix for a separate API model for Soundcloud responses. This will allow us to grow our own internal domain models independently of soundcloud's API.