### PR TITLE
Chatroom Domain Model

### DIFF
--- a/src/chatroom.rs
+++ b/src/chatroom.rs
@@ -45,7 +45,7 @@ impl<T> Chatroom<T> where
             return;
         }
 
-        self.current_users.push(user.clone());
+        self.current_users.push(user);
     }
 
     pub fn leave(&mut self, user_id: u32) {

--- a/src/chatroom.rs
+++ b/src/chatroom.rs
@@ -3,6 +3,7 @@ use crate::repositories::abstractions::Repository;
 use crate::user::{UserID, User, Username};
 use rusty_ulid::Ulid;
 use std::collections::VecDeque;
+use crate::Song;
 
 #[derive(Clone)]
 pub struct ChatUser(pub UserID, pub Username);
@@ -77,6 +78,11 @@ impl<T> Chatroom<T> where
 
     pub fn djs(&self) -> &VecDeque<DJ> {
         self.waitlist.djs()
+    }
+
+    pub fn play_next(&mut self) -> Result<Option<Song>, T::Error>{
+        // TODO: We probably need to actually hand the song over for streaming somehow here.
+        self.waitlist.play_next()
     }
 }
 

--- a/src/chatroom.rs
+++ b/src/chatroom.rs
@@ -1,0 +1,160 @@
+use crate::waitlist::{Waitlist, DJ};
+use crate::repositories::abstractions::Repository;
+use crate::user::{UserID, User, Username};
+use rusty_ulid::Ulid;
+use std::collections::VecDeque;
+
+#[derive(Clone)]
+pub struct ChatUser(pub UserID, pub Username);
+
+pub(crate) struct Chatroom<T> where
+    T: Repository<u32, User>,
+{
+    id: Ulid,
+    moderator: UserID,
+    waitlist: Waitlist<T>,
+    current_users: Vec<ChatUser>,
+}
+
+impl<T> Chatroom<T> where
+    T: Repository<u32, User>,
+{
+    pub fn new(user_repo: T, creating_user: UserID) -> Chatroom<T> {
+        Chatroom {
+            id: Ulid::generate(),
+            moderator: creating_user,
+            waitlist: Waitlist::new(user_repo),
+            current_users: Vec::new(),
+        }
+    }
+
+    pub fn moderator(&self) -> UserID {
+        self.moderator
+    }
+
+    pub fn change_moderator(&mut self, new_moderator: UserID) {
+        self.moderator = new_moderator;
+    }
+
+    pub fn enter(&mut self, user: &ChatUser) {
+        self.current_users.push(user.clone());
+    }
+
+    pub fn leave(&mut self, user_id: u32) {
+        let maybe_user_idx = self.current_users.iter().position(|u| {
+            u.0 == user_id
+        });
+
+        if let Some(user_idx) = maybe_user_idx {
+            self.current_users.remove(user_idx);
+        }
+    }
+
+    pub fn join_waitlist(&mut self, user_id: u32) {
+        // First make sure user is in chatroom.
+        let dj_result : Vec<&ChatUser> = self.current_users.iter()
+            .filter(|u| {
+                u.0 == user_id
+        }).collect();
+
+        if dj_result.len() != 1 {
+            // TODO: This should probably be an error.
+            return;
+        }
+
+        let dj = (dj_result[0].0, dj_result[0].1.clone());
+
+        self.waitlist.join(dj);
+    }
+
+    pub fn leave_waitlist(&mut self, user_id: u32) {
+        self.waitlist.leave(user_id);
+    }
+
+    pub fn len(&self) -> usize {
+        self.current_users.len()
+    }
+
+    pub fn djs(&self) -> &VecDeque<DJ> {
+        self.waitlist.djs()
+    }
+}
+
+impl<T> Clone for Chatroom<T> where
+    T: Repository<u32, User> + Clone,
+{
+    fn clone(&self) -> Self {
+        Chatroom {
+            id: self.id.clone(),
+            moderator: self.moderator.clone(),
+            waitlist: self.waitlist.clone(),
+            current_users: self.current_users.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_tools::factories::{TestChatroomSpec, new_test_chatroom};
+    use std::collections::VecDeque;
+
+    #[test]
+    #[allow(unused)]
+    fn test_chatroom_leave() {
+        let spec = TestChatroomSpec {
+            chatroom_user_count: 4,
+            playlist_per_user: 1,
+            song_per_playlist: 2,
+            // test user 1, and test user 3 joined the waitlist.
+            which_joined_waitlist: vec![1, 3],
+            moderator_user: 1,
+            which_forgot_active: None,
+        };
+        let mut chatroom = new_test_chatroom(spec);
+        assert_eq!(chatroom.len(), 4);
+
+        chatroom.leave(0);
+        assert_eq!(chatroom.len(), 3);
+    }
+
+    #[test]
+    #[allow(unused)]
+    fn test_chatroom_moderator() {
+        let spec = TestChatroomSpec {
+            chatroom_user_count: 4,
+            playlist_per_user: 1,
+            song_per_playlist: 2,
+            // test user 1, and test user 3 joined the waitlist.
+            which_joined_waitlist: vec![1, 3],
+            moderator_user: 1,
+            which_forgot_active: None,
+        };
+        let mut chatroom = new_test_chatroom(spec);
+        assert_eq!(chatroom.moderator(), 0);
+
+        chatroom.change_moderator(2);
+        assert_eq!(chatroom.moderator(), 2)
+    }
+
+    #[test]
+    #[allow(unused)]
+    fn test_waitlist_working() {
+        let spec = TestChatroomSpec {
+            chatroom_user_count: 4,
+            playlist_per_user: 1,
+            song_per_playlist: 2,
+            // test user 1, and test user 3 joined the waitlist.
+            which_joined_waitlist: vec![1, 3],
+            moderator_user: 1,
+            which_forgot_active: None,
+        };
+        let mut chatroom = new_test_chatroom(spec);
+        let want = VecDeque::from(vec![
+            (0, "test_username".to_string()),
+            (2, "test_username".to_string())
+        ]);
+        let got = chatroom.djs();
+
+        assert_eq!(got, &want)
+    }
+}

--- a/src/chatroom.rs
+++ b/src/chatroom.rs
@@ -12,6 +12,7 @@ pub(crate) struct Chatroom<T> where
     T: Repository<u32, User>,
 {
     id: Ulid,
+    name: String,
     moderator: UserID,
     waitlist: Waitlist<T>,
     current_users: Vec<ChatUser>,
@@ -20,9 +21,10 @@ pub(crate) struct Chatroom<T> where
 impl<T> Chatroom<T> where
     T: Repository<u32, User>,
 {
-    pub fn new(user_repo: T, creating_user: UserID) -> Chatroom<T> {
+    pub fn new(user_repo: T, creating_user: UserID, chatroom_name: String) -> Chatroom<T> {
         Chatroom {
             id: Ulid::generate(),
+            name: chatroom_name,
             moderator: creating_user,
             waitlist: Waitlist::new(user_repo),
             current_users: Vec::new(),
@@ -93,6 +95,7 @@ impl<T> Clone for Chatroom<T> where
     fn clone(&self) -> Self {
         Chatroom {
             id: self.id.clone(),
+            name: self.name.clone(),
             moderator: self.moderator.clone(),
             waitlist: self.waitlist.clone(),
             current_users: self.current_users.clone(),

--- a/src/chatroom.rs
+++ b/src/chatroom.rs
@@ -49,13 +49,7 @@ impl<T> Chatroom<T> where
     }
 
     pub fn leave(&mut self, user_id: u32) {
-        let maybe_user_idx = self.current_users.iter().position(|u| {
-            u.0 == user_id
-        });
-
-        if let Some(user_idx) = maybe_user_idx {
-            self.current_users.remove(user_idx);
-        }
+        self.current_users.retain(|u| u.0 != user_id);
     }
 
     pub fn join_waitlist(&mut self, user_id: u32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,9 @@ pub mod user;
 pub mod song;
 pub use song::*;
 
-pub mod playlist;
-
+pub mod chatroom;
 pub mod waitlist;
+pub mod playlist;
 
 pub mod test_tools;
 pub use test_tools::*;

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -13,7 +13,7 @@ impl Playlist {
     pub fn new(name: String) -> Playlist {
         Playlist {
             id: Ulid::generate(),
-            name: name,
+            name,
             songs: VecDeque::new(),
         }
     }

--- a/src/repositories/abstractions.rs
+++ b/src/repositories/abstractions.rs
@@ -2,9 +2,9 @@ pub(crate) trait Repository<K, V> {
     /// An error that communicates that something went wrong when communicating with the external api, database etc.
     type Error: std::error::Error + std::fmt::Display + 'static + Send;
 
-    /// Inserts a User into the underlying persistent storage (MySQL, Postgres, Mongo etc.).
+    /// Inserts a Entity into the underlying persistent storage (MySQL, Postgres, Mongo etc.).
     ///
-    /// If the underlying storage did not have the User present, then insert is successful and the primary key is returned.
+    /// If the underlying storage did not have the Entity present, then insert is successful and the primary key is returned.
     /// This allows for auto-generated ids to be returned after insert.
     ///
     /// If the underlying storage does have the key present, then [`None`] is returned.
@@ -16,7 +16,7 @@ pub(crate) trait Repository<K, V> {
     /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
     fn insert(&mut self, entity: &V) -> Result<Option<K>, Self::Error>;
 
-    /// Returns the User with the supplied user_id as an owned type.
+    /// Returns the Entity with the supplied key as an owned type.
     ///
     /// # Failure case
     ///
@@ -33,8 +33,8 @@ pub(crate) trait Repository<K, V> {
         Ok(self.get(key)?.is_some())
     }
 
-    /// Updates the User in the underlying storage mechanism and if successful returns the primary
-    /// key to the caller. If the User does not exist in the database (it's unique
+    /// Updates the Entity in the underlying storage mechanism and if successful returns the primary
+    /// key to the caller. If the Entity does not exist in the database (it's unique
     /// id is not in use), then we return [`None`].
     ///
     /// # Failure case
@@ -43,8 +43,8 @@ pub(crate) trait Repository<K, V> {
     /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
     fn update(&mut self, entity: &V) -> Result<Option<K>, Self::Error>;
 
-    /// Removes a User from the underlying storage at the given user_id,
-    /// returning the user_id if the user was in the database and deleted, and otherwise returning [`None`]
+    /// Removes a Entity from the underlying storage at the given key,
+    /// returning the key if the entity was in the database and deleted, and otherwise returning [`None`]
     /// if the entity was not found (no rows effected by the operation).
     ///
     /// # Failure case

--- a/src/test_tools/factories.rs
+++ b/src/test_tools/factories.rs
@@ -152,7 +152,7 @@ pub(crate) fn new_test_chatroom(spec: TestChatroomSpec) -> Chatroom<MockUserRepo
         user.add_playlist(playlist);
         user_repo.insert(&user);
     }
-    let mut chatroom = Chatroom::new(user_repo, spec.moderator_user-1);
+    let mut chatroom = Chatroom::new(user_repo, spec.moderator_user-1, "test_chatroom".to_string());
 
     let waitlist_set: HashSet<u32> = spec.which_joined_waitlist.into_iter().collect();
 

--- a/src/test_tools/factories.rs
+++ b/src/test_tools/factories.rs
@@ -157,7 +157,7 @@ pub(crate) fn new_test_chatroom(spec: TestChatroomSpec) -> Chatroom<MockUserRepo
     let waitlist_set: HashSet<u32> = spec.which_joined_waitlist.into_iter().collect();
 
     for (i, user) in users.iter().enumerate() {
-        chatroom.enter(&ChatUser(user.id(), user.username()));
+        chatroom.join(ChatUser(user.id(), user.username()));
         if waitlist_set.contains(&(i as u32 + 1)) {
             chatroom.join_waitlist(user.id())
         }


### PR DESCRIPTION
This PR adds a `Chatroom` domain model that should be used for all functions you need to carry out in a chatroom, including leaving or entering a dj waitlist. Waitlist methods are available via the Chatroom domain model.

Fixes #12 